### PR TITLE
No bundle necessary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+Dockerfile.jupyter

--- a/neuroscout_cli/__init__.py
+++ b/neuroscout_cli/__init__.py
@@ -1,2 +1,2 @@
 __version__ = '0.1'
-API_URL = 'http://alpha.neuroscout.org/api/'
+API_URL = 'https://alpha.neuroscout.org/api/'

--- a/neuroscout_cli/cli.py
+++ b/neuroscout_cli/cli.py
@@ -2,7 +2,7 @@
 neuroscout
 
 Usage:
-    neuroscout run <bundle_id> [-dn -o <out_dir> -i <install_dir> --n-cpus=<n> --work-dir=<dir>]
+    neuroscout run <bundle_id> [-dn -o <out_dir> -i <install_dir> --n-cpus=<n> --work-dir=<dir> --dataset-name=<name>]
     neuroscout install <bundle_id> [-dn -i <install_dir>]
     neuroscout ls <bundle_id>
     neuroscout -h | --help
@@ -14,6 +14,7 @@ Options:
     --work-dir=<dir>        Working directory
     --n-cpus=<n>            Maximum number of threads across all processes [default: 1]
     -n, --no-download       Dont download dataset (if available locally)
+    --dataset-name=<name>   Manually specify dataset name
     -h --help               Show this screen
     -v, --version           Show version
     -d, --debug             Debug mode
@@ -28,7 +29,7 @@ Examples:
 
 Help:
     For help using this tool, please open an issue on the Github
-    repository: https://github.com/PsychoinformaticsLab/neuroscout-cli.
+    repository: https://github.com/neuroscout/neuroscout-cli.
 
     For help using neuroscout and creating a bundle, visit www.neuroscout.org.
 """
@@ -50,6 +51,5 @@ def main():
         if hasattr(neuroscout_cli.commands, k) and v:
             k = k[0].upper() + k[1:]
             command = getattr(neuroscout_cli.commands, k)
-            command = command(args)
-            command.run()
+            command(args).run()
             sys.exit(0)

--- a/neuroscout_cli/commands/run.py
+++ b/neuroscout_cli/commands/run.py
@@ -33,7 +33,7 @@ class Run(Command):
         ]
 
         # Fitlins invalid keys
-        invalid = ['--no-download', '--version', '--help', '-i', 'run', '<bundle_id>']
+        invalid = ['--no-download', '--version', '--help', '-i', 'run', '<bundle_id>', '--dataset-name']
         for k in invalid:
             self.options.pop(k, None)
 


### PR DESCRIPTION
If dataset name is specified, bundle downloading should not be necessary, if the contets are available in the dataset directory. This is useful in case of connectivity problems.

Also:
 - Updated `.gitignore`
 - Updated docstring
 - Added exception handling for connectivity errors.