### PR TITLE
ENH: Update Neuroscout-CLI to new fitlins/pybids 0.7

### DIFF
--- a/neuroscout_cli/cli.py
+++ b/neuroscout_cli/cli.py
@@ -31,26 +31,26 @@ Help:
 
     For help using neuroscout and creating a bundle, visit www.neuroscout.org.
 """
-
-from docopt import docopt
-from . import __version__ as VERSION
 import sys
 from copy import deepcopy
+from docopt import docopt
+from . import __version__ as VERSION
+
 
 def main():
     # CLI entry point
     import neuroscout_cli.commands
     args = docopt(__doc__, version=VERSION)
 
-    for (k, v) in args.items():
-        if hasattr(neuroscout_cli.commands, k) and v:
+    for (k, val) in args.items():
+        if hasattr(neuroscout_cli.commands, k) and val:
             k = k[0].upper() + k[1:]
             command = getattr(neuroscout_cli.commands, k)
             if k in ['Run', 'Install']:
                 bundles = args.pop('<bundle_id>')
                 # Loop over bundles
-                for b in bundles:
-                    print("Running bundle {}".format(b))
-                    args['<bundle_id>'] = b
+                for bundle in bundles:
+                    print("Running bundle {}".format(bundle))
+                    args['<bundle_id>'] = bundle
                     command(deepcopy(args)).run()
             sys.exit(0)

--- a/neuroscout_cli/commands/base.py
+++ b/neuroscout_cli/commands/base.py
@@ -4,6 +4,7 @@ from abc import ABCMeta, abstractmethod
 from pathlib import Path
 from pyns import Neuroscout
 
+
 class Command(metaclass=ABCMeta):
 
     ''' A base command'''

--- a/neuroscout_cli/commands/install.py
+++ b/neuroscout_cli/commands/install.py
@@ -78,7 +78,7 @@ class Install(Command):
             message = e.failed[0]['message']
             raise ValueError("Datalad failed. Reason: {}".format(message))
 
-        desc = {'Name': self.dataset_dir.parts[0], 'BIDSVersion': '1.0'}
+        desc = {'Name': self.dataset_dir.parts[0], 'BIDSVersion': '1.1.1'}
 
         with (self.dataset_dir / 'dataset_description.json').open('w') as f:
             json.dump(desc, f)

--- a/neuroscout_cli/commands/install.py
+++ b/neuroscout_cli/commands/install.py
@@ -76,18 +76,7 @@ class Install(Command):
                     unlock(paths)
         except Exception as e:
             message = e.failed[0]['message']
-            if 'Failed to clone data from any candidate' not in message[0]:
-                raise ValueError("Datalad failed. Reason: {}".format(message))
-
-            logging.info("Attempting HTTP download...")
-            for i, resource in enumerate(remote_files):
-                filename = preproc_dir / resource
-                logging.info("{}/{}: {}".format(
-                    i+1, len(remote_files), resource))
-
-                if not filename.exists():
-                    filename.parents[0].mkdir(exist_ok=True, parents=True)
-                    download_file(remote_path + '/' + resource, filename)
+            raise ValueError("Datalad failed. Reason: {}".format(message))
 
         desc = {'Name': self.dataset_dir.parts[0], 'BIDSVersion': '1.0'}
 

--- a/neuroscout_cli/commands/install.py
+++ b/neuroscout_cli/commands/install.py
@@ -68,7 +68,7 @@ class Install(Command):
             if (preproc_dir / 'fmriprep').exists():
                 paths = [str(preproc_dir / 'fmriprep' / f) for f in remote_files]
                 get(paths)
-                ### Also get dataset_description!
+                get(str(preproc_dir / 'dataset_description.json'))
                 if self.options.pop('--unlock', False):
                     unlock(paths)
         except Exception as e:

--- a/neuroscout_cli/commands/install.py
+++ b/neuroscout_cli/commands/install.py
@@ -39,7 +39,8 @@ class Install(Command):
             tf.extractfile('resources.json').read().decode("utf-8"))
 
         self.dataset_dir = self.install_dir / self.resources['dataset_name']
-        self.bundle_dir = self.dataset_dir / 'derivatives' / 'neuroscout' / self.bundle_id
+        self.bundle_dir = self.dataset_dir \
+            / 'derivatives' / 'neuroscout' / self.bundle_id
 
         # Probably need to add option to force-redownload
         if not self.bundle_dir.exists():
@@ -55,7 +56,8 @@ class Install(Command):
     def download_data(self):
         self.download_bundle()
 
-        remote_files = self.resources['func_paths'] + self.resources['mask_paths']
+        remote_files = self.resources['func_paths'] + \
+            self.resources['mask_paths']
         remote_path = self.resources['preproc_address']
 
         preproc_dir = Path(self.dataset_dir) / 'derivatives' / 'fmriprep'
@@ -66,7 +68,8 @@ class Install(Command):
                 install(source=remote_path,
                         path=str(preproc_dir))
             if (preproc_dir / 'fmriprep').exists():
-                paths = [str(preproc_dir / 'fmriprep' / f) for f in remote_files]
+                paths = [str(preproc_dir / 'fmriprep' / f)
+                         for f in remote_files]
                 get(paths)
                 get(str(preproc_dir / 'dataset_description.json'))
                 if self.options.pop('--unlock', False):
@@ -79,7 +82,8 @@ class Install(Command):
             logging.info("Attempting HTTP download...")
             for i, resource in enumerate(remote_files):
                 filename = preproc_dir / resource
-                logging.info("{}/{}: {}".format(i+1, len(remote_files), resource))
+                logging.info("{}/{}: {}".format(
+                    i+1, len(remote_files), resource))
 
                 if not filename.exists():
                     filename.parents[0].mkdir(exist_ok=True, parents=True)
@@ -99,8 +103,10 @@ class Install(Command):
         if self.options.pop('--no-download', False):
             return self.download_bundle()
         elif self.options.get('--dataset-name', False):
-            self.dataset_dir = self.install_dir / self.options.pop('--dataset-name')
-            self.bundle_dir = self.dataset_dir / 'derivatives' / 'neuroscout' / self.bundle_id
+            self.dataset_dir = self.install_dir \
+                / self.options.pop('--dataset-name')
+            self.bundle_dir = self.dataset_dir \
+                / 'derivatives' / 'neuroscout' / self.bundle_id
             if self.bundle_dir.exists():
                 return self.bundle_dir.absolute()
             else:

--- a/neuroscout_cli/commands/install.py
+++ b/neuroscout_cli/commands/install.py
@@ -60,20 +60,20 @@ class Install(Command):
             self.resources['mask_paths']
         remote_path = self.resources['preproc_address']
 
-        preproc_dir = Path(self.dataset_dir) / 'derivatives' / 'fmriprep'
+        self.preproc_dir = Path(self.dataset_dir) / 'derivatives' / 'fmriprep'
 
         try:
-            if not preproc_dir.exists():
+            if not self.preproc_dir.exists():
                 # Use datalad to install the raw BIDS dataset
                 install(source=remote_path,
-                        path=str(preproc_dir))
-            if (preproc_dir / 'fmriprep').exists():
-                paths = [str(preproc_dir / 'fmriprep' / f)
-                         for f in remote_files]
-                get(paths)
-                get(str(preproc_dir / 'dataset_description.json'))
-                if self.options.pop('--unlock', False):
-                    unlock(paths)
+                        path=str(self.preproc_dir))
+            paths = [str(self.preproc_dir / 'fmriprep' / f)
+                     for f in remote_files]
+            get(paths)
+            get(str(
+                self.preproc_dir / 'fmriprep' / 'dataset_description.json'))
+            if self.options.pop('--unlock', False):
+                unlock(paths)
         except Exception as e:
             message = e.failed[0]['message']
             raise ValueError("Datalad failed. Reason: {}".format(message))

--- a/neuroscout_cli/commands/run.py
+++ b/neuroscout_cli/commands/run.py
@@ -31,7 +31,7 @@ class Run(Command):
             '--exclude=(fmriprep.*$(?<=tsv))'.format(bundle_path.parts[-1]),
             '--derivatives={}'.format(bundle_path),
             '--derivatives={}'.format(
-                install_command.preproc_dir / 'fmriprep')
+                install_command.preproc_dir.absolute() / 'fmriprep')
         ]
 
         # Fitlins invalid keys

--- a/neuroscout_cli/commands/run.py
+++ b/neuroscout_cli/commands/run.py
@@ -6,7 +6,9 @@ import shutil
 from pathlib import Path
 
 # Options not to be passed onto fitlins
-INVALID = ['--unlock', '--no-download', '--version', '--help', '--install-dir', 'run', '<bundle_id>', '--dataset-name']
+INVALID = ['--unlock', '--no-download', '--version', '--help', '--install-dir',
+           'run', '<bundle_id>', '--dataset-name']
+
 
 class Run(Command):
     ''' Command for running neuroscout workflows. '''
@@ -21,13 +23,12 @@ class Run(Command):
 
         dataset_dir = install_command.dataset_dir.absolute()
 
-        ## Set up fitlins args
         fitlins_args = [
             dataset_dir.as_posix(),
             tmp_out,
             'dataset',
-            '--model={}'.format((bundle_path / 'model.json').absolute().as_posix()),
-            '--exclude=(neuroscout/(?!{})|fmriprep.*$(?<=tsv)|/.git)'.format(bundle_path.parts[-1])
+            '--model={}'.format((bundle_path / 'model.json').absolute()),
+            '--exclude=(fmriprep.*$(?<=tsv))'.format(bundle_path.parts[-1])
         ]
 
         # Fitlins invalid keys

--- a/neuroscout_cli/commands/run.py
+++ b/neuroscout_cli/commands/run.py
@@ -16,7 +16,7 @@ class Run(Command):
         install = Install(self.options.copy())
         bundle_path = install.run()
 
-        out_dir = Path(self.options.pop('<outdir>'))
+        out_dir = Path(self.options.pop('<outdir>')) / install.bundle_id
 
         dataset_dir = install.dataset_dir.absolute()
 

--- a/neuroscout_cli/commands/run.py
+++ b/neuroscout_cli/commands/run.py
@@ -28,7 +28,10 @@ class Run(Command):
             tmp_out,
             'dataset',
             '--model={}'.format((bundle_path / 'model.json').absolute()),
-            '--exclude=(fmriprep.*$(?<=tsv))'.format(bundle_path.parts[-1])
+            '--exclude=(fmriprep.*$(?<=tsv))'.format(bundle_path.parts[-1]),
+            '--derivatives={}'.format(bundle_path),
+            '--derivatives={}'.format(
+                install_command.preproc_dir / 'fmriprep')
         ]
 
         # Fitlins invalid keys

--- a/neuroscout_cli/commands/run.py
+++ b/neuroscout_cli/commands/run.py
@@ -13,12 +13,12 @@ class Run(Command):
 
     def run(self):
         # Download bundle and install dataset if necessary
-        install_command = Install(self.options.copy())
-        bundle_path = install_command.run()
+        install = Install(self.options.copy())
+        bundle_path = install.run()
 
         out_dir = Path(self.options.pop('<outdir>'))
 
-        dataset_dir = install_command.dataset_dir.absolute()
+        dataset_dir = install.dataset_dir.absolute()
 
         fitlins_args = [
             str(dataset_dir),
@@ -26,9 +26,8 @@ class Run(Command):
             'dataset',
             '--model={}'.format((bundle_path / 'model.json').absolute()),
             '--exclude=(fmriprep.*$(?<=tsv))'.format(bundle_path.parts[-1]),
-            '--derivatives={}'.format(bundle_path),
-            '--derivatives={}'.format(
-                install_command.preproc_dir.absolute() / 'fmriprep')
+            '--derivatives={} {}'.format(
+                bundle_path, install.preproc_dir.absolute() / 'fmriprep'),
         ]
 
         # Fitlins invalid keys

--- a/neuroscout_cli/commands/run.py
+++ b/neuroscout_cli/commands/run.py
@@ -1,8 +1,6 @@
 from neuroscout_cli.commands.base import Command
 from neuroscout_cli.commands.install import Install
 from fitlins.cli.run import run_fitlins
-from tempfile import mkdtemp
-import shutil
 from pathlib import Path
 
 # Options not to be passed onto fitlins
@@ -19,13 +17,12 @@ class Run(Command):
         bundle_path = install_command.run()
 
         out_dir = Path(self.options.pop('<outdir>'))
-        tmp_out = mkdtemp()
 
         dataset_dir = install_command.dataset_dir.absolute()
 
         fitlins_args = [
-            dataset_dir.as_posix(),
-            tmp_out,
+            str(dataset_dir),
+            str(out_dir),
             'dataset',
             '--model={}'.format((bundle_path / 'model.json').absolute()),
             '--exclude=(fmriprep.*$(?<=tsv))'.format(bundle_path.parts[-1]),
@@ -51,5 +48,3 @@ class Run(Command):
 
         # Call fitlins as if CLI
         run_fitlins(fitlins_args)
-        # Copy to out_dir (doing this because of Windows volume)
-        shutil.copytree(Path(tmp_out) / 'fitlins', out_dir / self.bundle_id)


### PR DESCRIPTION
Fixes #52 
Related to: https://github.com/effigies/fitlins/pull/1

- [x]  It looks TR is not being read by `get_metadata` for preproc images, because`get_metadata` does not go across derivatives (TR info is in `neuroscout`, image is in `fmiprep`. Need to move this file to the root of `bids_dir`. Not sure what the best way to package it is. 
- [x] Regarding `exclude`, it wont be as necessary if `.git` folders are excluded by default, and we can just specify both the `fmriprep` and specific `neuroscout` folder to include. 