### PR TITLE
Always copy task description

### DIFF
--- a/neuroscout_cli/cli.py
+++ b/neuroscout_cli/cli.py
@@ -34,7 +34,7 @@ Help:
 import sys
 from copy import deepcopy
 from docopt import docopt
-from . import __version__ as VERSION
+from neuroscout_cli import __version__ as VERSION
 
 
 def main():

--- a/neuroscout_cli/commands/install.py
+++ b/neuroscout_cli/commands/install.py
@@ -50,8 +50,8 @@ class Install(Command):
             tf.extractall(self.bundle_dir)
             logging.info(
                 "Bundle installed at {}".format(self.bundle_dir.absolute()))
-            # Copy meta-data to root of dataset_dir
-            copy(list(self.bundle_dir.glob('task-*json'))[0], self.dataset_dir)
+        # Copy meta-data to root of dataset_dir
+        copy(list(self.bundle_dir.glob('task-*json'))[0], self.dataset_dir)
 
         return self.bundle_dir.absolute()
 


### PR DESCRIPTION
Fixes issue where description was not being copied over to dataset dir if a bundle dir was found (yet it could still not exist on dataset dir). This led to no RT being found by pybids. 