### PR TITLE
No mock raw directory, change workdir to /work + other improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN /bin/bash -c "source activate neuro \
       && pip install -q --no-cache-dir --upgrade -r /src/neuroscout/requirements.txt" \
     && sync
 
-WORKDIR /data
+WORKDIR /work
 
 # Change entrypoint to neuroscout
 ENTRYPOINT ["/neurodocker/startup.sh", "neuroscout"]

--- a/neuroscout_cli/cli.py
+++ b/neuroscout_cli/cli.py
@@ -2,7 +2,7 @@
 neuroscout
 
 Usage:
-    neuroscout run [-nui <dir> -w <dir> -c <n> -d <n>] <outdir> <bundle_id>...
+    neuroscout run [-nui <dir> -w <dir> -c <n>] <outdir> <bundle_id>...
     neuroscout install [-nui <dir>] <bundle_id>...
     neuroscout ls <bundle_id>
     neuroscout -h | --help
@@ -11,9 +11,9 @@ Usage:
 Options:
     -i, --install-dir <dir>  Directory to download data [default: .]
     -w, --work-dir <dir>     Working directory
-    -c, --n-cpus <n>         Maximum number of threads across all processes [default: 1]
-    -d, --dataset-name <n>   Manually specify dataset name
-    -n, --no-download        Dont download dataset
+    -c, --n-cpus <n>         Maximum number of threads across all processes
+                             [default: 1]
+    -n, --no-download        Don't attempt to download dataset
     -u, --unlock             Unlock datalad dataset
 
 Commands:
@@ -35,22 +35,24 @@ import sys
 from copy import deepcopy
 from docopt import docopt
 from neuroscout_cli import __version__ as VERSION
+import neuroscout_cli.commands as ncl
+import logging
+logging.getLogger().setLevel(logging.INFO)
 
 
 def main():
     # CLI entry point
-    import neuroscout_cli.commands
     args = docopt(__doc__, version=VERSION)
 
     for (k, val) in args.items():
-        if hasattr(neuroscout_cli.commands, k) and val:
+        if hasattr(ncl, k) and val:
             k = k[0].upper() + k[1:]
-            command = getattr(neuroscout_cli.commands, k)
+            command = getattr(ncl, k)
             if k in ['Run', 'Install']:
                 bundles = args.pop('<bundle_id>')
                 # Loop over bundles
                 for bundle in bundles:
-                    print("Running bundle {}".format(bundle))
+                    logging.info("Running analysis : {}".format(bundle))
                     args['<bundle_id>'] = bundle
                     command(deepcopy(args)).run()
             sys.exit(0)

--- a/neuroscout_cli/commands/base.py
+++ b/neuroscout_cli/commands/base.py
@@ -16,6 +16,7 @@ class Command(metaclass=ABCMeta):
         self.kwargs = kwargs
         self.home = Path.home() / '.neuroscout'
         self.home.mkdir(exist_ok=True)
+        self.bundle_cache = (self.home / self.bundle_id).with_suffix(".tar.gz")
         self.api = Neuroscout()
 
     @abstractmethod

--- a/neuroscout_cli/commands/install.py
+++ b/neuroscout_cli/commands/install.py
@@ -29,6 +29,11 @@ class Install(Command):
             self.resources = json.loads(
                 tf.extractfile('resources.json').read().decode("utf-8"))
 
+            self.dataset_dir = self.install_dir / \
+                self.resources['dataset_name']
+            self.bundle_dir = self.dataset_dir \
+                / 'neuroscout-bundles' / self.bundle_id
+
             #  Extract to bundle_dir
             if not self.bundle_dir.exists():
                 self.bundle_dir.mkdir(parents=True, exist_ok=True)
@@ -36,10 +41,6 @@ class Install(Command):
                 logging.info(
                     "Bundle installed at {}".format(
                         self.bundle_dir.absolute()))
-
-        self.dataset_dir = self.install_dir / self.resources['dataset_name']
-        self.bundle_dir = self.dataset_dir \
-            / 'neuroscout-bundles' / self.bundle_id
 
         return self.bundle_dir.absolute()
 

--- a/neuroscout_cli/commands/install.py
+++ b/neuroscout_cli/commands/install.py
@@ -25,20 +25,21 @@ class Install(Command):
             self.api.analyses.bundle(self.bundle_id, self.bundle_cache)
 
         # Un-tarzip, and read in JSON files
-        tf = tarfile.open(self.bundle_cache)
-        self.resources = json.loads(
-            tf.extractfile('resources.json').read().decode("utf-8"))
+        with tarfile.open(self.bundle_cache) as tf:
+            self.resources = json.loads(
+                tf.extractfile('resources.json').read().decode("utf-8"))
+
+            #  Extract to bundle_dir
+            if not self.bundle_dir.exists():
+                self.bundle_dir.mkdir(parents=True, exist_ok=True)
+                tf.extractall(self.bundle_dir)
+                logging.info(
+                    "Bundle installed at {}".format(
+                        self.bundle_dir.absolute()))
 
         self.dataset_dir = self.install_dir / self.resources['dataset_name']
         self.bundle_dir = self.dataset_dir \
             / 'neuroscout-bundles' / self.bundle_id
-
-        #  Extract to bundle_dir
-        if not self.bundle_dir.exists():
-            self.bundle_dir.mkdir(parents=True, exist_ok=True)
-            tf.extractall(self.bundle_dir)
-            logging.info(
-                "Bundle installed at {}".format(self.bundle_dir.absolute()))
 
         return self.bundle_dir.absolute()
 

--- a/neuroscout_cli/commands/install.py
+++ b/neuroscout_cli/commands/install.py
@@ -10,9 +10,6 @@ from tqdm import tqdm
 from bids.utils import convert_JSON
 from bids import BIDSLayout
 
-logging.getLogger().setLevel(logging.INFO)
-
-
 def download_file(url, path):
     # Streaming, so we can iterate over the response.
     r = requests.get(url, stream=True)
@@ -31,48 +28,52 @@ class Install(Command):
 
     ''' Command for retrieving neuroscout bundles and their corresponding
     data. '''
+
+    def __init__(self, options, *args, **kwargs):
+        super().__init__(options, *args, **kwargs)
+        self.install_dir = Path(self.options.pop('--install-dir'))
+
     def download_bundle(self):
+        # Download bundle
         if not self.bundle_cache.exists():
             logging.info("Downloading bundle...")
             self.api.analyses.bundle(self.bundle_id, self.bundle_cache)
 
+        # Un-tarzip, and read in JSON files
         tf = tarfile.open(self.bundle_cache)
         self.resources = json.loads(
             tf.extractfile('resources.json').read().decode("utf-8"))
 
         self.dataset_dir = self.install_dir / self.resources['dataset_name']
         self.bundle_dir = self.dataset_dir \
-            / 'derivatives' / 'neuroscout' / self.bundle_id
+            / 'neuroscout-bundles' / self.bundle_id
 
-        # Probably need to add option to force-redownload
+        #  Extract to bundle_dir
         if not self.bundle_dir.exists():
             self.bundle_dir.mkdir(parents=True, exist_ok=True)
             tf.extractall(self.bundle_dir)
             logging.info(
                 "Bundle installed at {}".format(self.bundle_dir.absolute()))
-        # Copy meta-data to root of dataset_dir
-        copy(list(self.bundle_dir.glob('task-*json'))[0], self.dataset_dir)
 
         return self.bundle_dir.absolute()
 
     def download_data(self):
         bundle_dir = self.download_bundle()
-        model = convert_JSON(json.load((bundle_dir / 'model.json').open()))
+        with (bundle_dir / 'model.json').open() as f:
+            model = convert_JSON(json.load(f))
 
-        remote_path = self.resources['preproc_address']
-
-        self.preproc_dir = Path(
-            self.dataset_dir) / 'derivatives' / 'fmriprep'
+        self.preproc_dir = Path(self.dataset_dir) / 'preproc' / 'fmriprep'
 
         try:
-            if not self.preproc_dir.exists():
-                # Use datalad to install the raw BIDS dataset
-                install(source=remote_path,
-                        path=str(self.preproc_dir))
+            if not self.preproc_dir.parents[0].exists():
+                # Use datalad to install the preproc dataset
+                install(source=self.resources['preproc_address'],
+                        path=str(self.preproc_dir.parents[0]))
 
-            layout = BIDSLayout(
-                str(self.preproc_dir / 'fmriprep'),
-                derivatives=str(self.preproc_dir / 'fmriprep'))
+            get(str(self.preproc_dir / 'dataset_description.json'))
+
+            layout = BIDSLayout(self.preproc_dir, derivatives=self.preproc_dir)
+
             paths = layout.get(
                 **model['input'], desc='preproc', return_type='file')
             paths += layout.get(
@@ -80,8 +81,7 @@ class Install(Command):
                 desc='brain', suffix='mask', return_type='file')
 
             get(paths)
-            get(str(
-                self.preproc_dir / 'fmriprep' / 'dataset_description.json'))
+
             if self.options.pop('--unlock', False):
                 unlock(paths)
 
@@ -89,29 +89,13 @@ class Install(Command):
             message = e.failed[0]['message']
             raise ValueError("Datalad failed. Reason: {}".format(message))
 
-        desc = {'Name': self.dataset_dir.parts[0], 'BIDSVersion': '1.1.1'}
-
-        with (self.dataset_dir / 'dataset_description.json').open('w') as f:
-            json.dump(desc, f)
+        # Copy meta-data to root of dataset_dir
+        copy(list(self.bundle_dir.glob('task-*json'))[0], self.preproc_dir)
 
         return self.bundle_dir.absolute()
 
     def run(self):
-        self.bundle_cache = (self.home / self.bundle_id).with_suffix(".tar.gz")
-        self.install_dir = Path(self.options.pop('--install-dir'))
-
         if self.options.pop('--no-download', False):
             return self.download_bundle()
-        elif self.options.get('--dataset-name', False):
-            self.dataset_dir = self.install_dir \
-                / self.options.pop('--dataset-name')
-            self.bundle_dir = self.dataset_dir \
-                / 'derivatives' / 'neuroscout' / self.bundle_id
-            if self.bundle_dir.exists():
-                return self.bundle_dir.absolute()
-            else:
-                raise ValueError(
-                    "Manually specified dataset directory does not contain",
-                    "analysis bundle. Try again, or re-download bundle.")
         else:
             return self.download_data()

--- a/neuroscout_cli/commands/install.py
+++ b/neuroscout_cli/commands/install.py
@@ -2,26 +2,11 @@ from neuroscout_cli.commands.base import Command
 from datalad.api import install, get, unlock
 from pathlib import Path
 from shutil import copy
-import requests
 import json
 import tarfile
 import logging
-from tqdm import tqdm
 from bids.utils import convert_JSON
 from bids import BIDSLayout
-
-def download_file(url, path):
-    # Streaming, so we can iterate over the response.
-    r = requests.get(url, stream=True)
-
-    # Total size in bytes.
-    total_size = int(r.headers.get('content-length', 0))
-    with open(path, 'wb') as f:
-        with tqdm(total=total_size, unit='B',
-                  unit_scale=True, unit_divisor=1024) as pbar:
-            for data in r.iter_content(32*1024):
-                f.write(data)
-                pbar.update(len(data))
 
 
 class Install(Command):

--- a/neuroscout_cli/commands/run.py
+++ b/neuroscout_cli/commands/run.py
@@ -15,19 +15,17 @@ class Run(Command):
         # Download bundle and install dataset if necessary
         install = Install(self.options.copy())
         bundle_path = install.run()
-
-        out_dir = Path(self.options.pop('<outdir>')) / install.bundle_id
-
-        dataset_dir = install.dataset_dir.absolute()
+        preproc_path = str(install.preproc_dir.absolute())
+        out_dir = str(Path(self.options.pop('<outdir>')) / install.bundle_id)
 
         fitlins_args = [
-            str(dataset_dir),
-            str(out_dir),
+            preproc_path,
+            out_dir,
             'dataset',
             '--model={}'.format((bundle_path / 'model.json').absolute()),
             '--ignore=/(fmriprep.*$(?<=tsv))/',
             '--derivatives={} {}'.format(
-                bundle_path, install.preproc_dir.absolute() / 'fmriprep'),
+                bundle_path, preproc_path),
         ]
 
         # Fitlins invalid keys


### PR DESCRIPTION
- [x] Instead of setting up a raw directory with derivatives (which is unnecessary), instead just download derivatives to `/data/dataset_name/preproc` and bundles to `/data/dataset_name/neuroscout-bundle/{bundle_id}`. Then use `/data/dataset_name/preproc/fmriprep` as the main dataset for `BIDSLayout`
- [x] Various refactoring of how paths are handled, to simplify
- [x] Remove custom dataset name option, as this was not needed for most uses, and confused API
- [x] Change workdir to /work. Closes #68 