### PR TITLE
[WIP] Add NeuroVault uploading

### DIFF
--- a/neuroscout_cli/cli.py
+++ b/neuroscout_cli/cli.py
@@ -2,7 +2,7 @@
 neuroscout
 
 Usage:
-    neuroscout run [-nui <dir> -w <dir> -c <n>] <outdir> <bundle_id>...
+    neuroscout run [-nfui <dir> -w <dir> -c <n>] <outdir> <bundle_id>...
     neuroscout install [-nui <dir>] <bundle_id>...
     neuroscout ls <bundle_id>
     neuroscout -h | --help
@@ -15,6 +15,7 @@ Options:
                              [default: 1]
     -n, --no-download        Don't attempt to download dataset
     -u, --unlock             Unlock datalad dataset
+    -f, --force-neurovault   Force NeuroVault upload (unique name)
 
 Commands:
     run                      Runs a first level, group level, or full analysis.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.6.2
 datalad==0.10.2
 tqdm==4.25.0
-pyns==0.1.2
+pyns==0.2.2


### PR DESCRIPTION
Uses pyNS to upload results from group level stat maps to NeuroVault. 
the `--force-neurovault` option pushes even if a collection with that names already exists, and appends a timestamp to the name. 

- [x] Find files, tarball, and upload