### PR TITLE
Fix NeuroVault uploads

### DIFF
--- a/neuroscout_cli/commands/run.py
+++ b/neuroscout_cli/commands/run.py
@@ -73,14 +73,14 @@ class Run(Command):
             images = images.glob('*stat*.nii.gz')
 
             # Make tarball
-            with tempfile.NamedTemporaryFile() as tf:
+            with tempfile.NamedTemporaryFile(delete=False) as tf:
                 with tarfile.open(fileobj=tf.file, mode="w:gz") as tar:
                     for path in images:
                         tar.add(path.absolute(), arcname=path.parts[-1])
 
-                # Upload results NeuroVault
-                self.api.analyses.upload_neurovault(
-                    self.bundle_id, tf.name,
-                    install.resources['validation_hash'],
-                    force=neurovault == 'force',
-                    n_subjects=n_subjects)
+            # Upload results NeuroVault
+            self.api.analyses.upload_neurovault(
+                self.bundle_id, tf.name,
+                install.resources['validation_hash'],
+                force=neurovault == 'force',
+                n_subjects=n_subjects)


### PR DESCRIPTION
- Close TF before uploading
- Don't say uploading when fitlins fails

Will leave off phoning home for failed runs etc for later. 