### PR TITLE
Add force-neurovault option, and default to group uploads

### DIFF
--- a/neuroscout_cli/cli.py
+++ b/neuroscout_cli/cli.py
@@ -2,7 +2,7 @@
 neuroscout
 
 Usage:
-    neuroscout run [-ui <dir> -s <k> -w <dir> -c <n> -n <nv> -d] <outdir> <bundle_id>...
+    neuroscout run [-dfu -i <dir> -s <k> -w <dir> -c <n> -n <nv>] <outdir> <bundle_id>...
     neuroscout install [-ui <dir>] <bundle_id>...
     neuroscout ls <bundle_id>
     neuroscout -h | --help
@@ -16,8 +16,9 @@ Options:
     -s, --smoothing <k>      Smoothing kernel FWHM at group level
                              [default: 4]
     -u, --unlock             Unlock datalad dataset
-    -n, --neurovault <nv>    Upload mode (disable, force, or enable)
-                             [default: enable]
+    -n, --neurovault <nv>    Upload mode (disable, all, or group)
+                             [default: group]
+    -f, --force-neurovault   Force upload, if a NV collection already exists
     -d, --drop-missing       Drop missing contrast
 
 Commands:

--- a/neuroscout_cli/commands/run.py
+++ b/neuroscout_cli/commands/run.py
@@ -35,8 +35,10 @@ class Run(Command):
             '--smoothing={}:Dataset'.format(smoothing)
         ]
 
-        neurovault = self.options.pop('--neurovault', 'enable')
-        assert neurovault in ['enable', 'disable', 'force']
+        neurovault = self.options.pop('--neurovault', 'group')
+        nv_force = self.options.pop('--force-neurovault', False)
+        if neurovault not in ['disable', 'group', 'all']:
+            raise ValueError("Invalid neurovault option.")
 
         # Fitlins invalid keys
         for k in INVALID:
@@ -74,15 +76,18 @@ class Run(Command):
                 group = [i for i in images.glob('task*statmap.nii.gz')
                          if re.match('.*stat-[t|variance|effect]+.*', i.name)]
 
-                sub = [i for i in images.glob('sub*/*statmap.nii.gz')
-                       if re.match('.*stat-[variance|effect]+.*', i.name)]
+                if neurovault == 'all':
+                    sub = [i for i in images.glob('sub*/*statmap.nii.gz')
+                           if re.match('.*stat-[variance|effect]+.*', i.name)]
+                else:
+                    sub = None
 
                 # Upload results NeuroVault
                 self.api.analyses.upload_neurovault(
                     id=self.bundle_id,
                     validation_hash=install.resources['validation_hash'],
                     group_paths=group, subject_paths=sub,
-                    force=neurovault == 'force',
+                    force=nv_force,
                     n_subjects=n_subjects)
         else:
             logging.error(
@@ -90,7 +95,7 @@ class Run(Command):
                 "-----------------------------------------------------------\n"
                 "Model execution failed! \n"
                 f"neuroscout-cli version: {VERSION}\n"
-                "Try updating or revising your model, and try again.\n"
+                "Update this program or revise your model, and try again.\n"
                 "If you believe there is a bug, please report it:\n"
                 "https://github.com/neuroscout/neuroscout-cli/issues\n"
                 "-----------------------------------------------------------\n"


### PR DESCRIPTION
For now, let's default to group only uploads, but allow subject uploads via CLI flag.

This adds a separate flag: `--force-neurovault` which is a boolean.

Closes #97 