### PR TITLE
Make JSON's optional

### DIFF
--- a/neuroscout_cli/commands/install.py
+++ b/neuroscout_cli/commands/install.py
@@ -64,7 +64,10 @@ class Install(Command):
                         path=str(self.preproc_dir.parents[0]))
 
             # Get all JSON files
-            get([str(p) for p in self.preproc_dir.rglob('*.json')])
+            jsons = list(self.preproc_dir.rglob('*.json'))
+            print(jsons)
+            if jsons:
+                get([str(p) for p in self.preproc_dir.rglob('*.json')])
 
             layout = BIDSLayout(
                 self.preproc_dir,


### PR DESCRIPTION
Some datasets have no JSON's to download, so make fetching them dependent on the result of glob.