### PR TITLE
FIX: Save dataset_dir to allow DataLad to get files

### DIFF
--- a/neuroscout_cli/cli.py
+++ b/neuroscout_cli/cli.py
@@ -77,7 +77,7 @@ def run(**kwargs):
 @click.argument('analysis_id')
 @click.option('--bundle-only', is_flag=True, help="Only fetch analysis bundle, not imaging data")
 @click.option('--download-dir', help='Directory to cache input datasets, instead of OUT_DIR', type=click.Path())
-@click.option('--datalad-jobs', help='Number of parallel jobs for DataLad when fetching files', default='auto', type=click.str())
+@click.option('--datalad-jobs', help='Number of parallel jobs for DataLad when fetching files', default='auto')
 @main.command()
 def get(**kwargs):
     """ Fetch analysis inputs.

--- a/neuroscout_cli/cli.py
+++ b/neuroscout_cli/cli.py
@@ -42,6 +42,7 @@ def main():
 @click.option('--upload-first-level', is_flag=True, help='Upload first-level results, in addition to group')
 @click.option('--force-upload', is_flag=True, help='Force upload even if a NV collection already exists')
 @click.option('--no-get', is_flag=True, help="Don't automatically fetch bundle & dataset")
+@click.option('--datalad-jobs', help='Number of parallel jobs for DataLad when fetching files', default='auto', type=click.str())
 @click.option('--download-dir', help='Directory to cache input datasets, instead of OUT_DIR', type=click.Path())
 @click.argument('fitlins_options', nargs=-1, type=click.UNPROCESSED)
 @main.command(context_settings=dict(
@@ -76,6 +77,7 @@ def run(**kwargs):
 @click.argument('analysis_id')
 @click.option('--bundle-only', is_flag=True, help="Only fetch analysis bundle, not imaging data")
 @click.option('--download-dir', help='Directory to cache input datasets, instead of OUT_DIR', type=click.Path())
+@click.option('--datalad-jobs', help='Number of parallel jobs for DataLad when fetching files', default='auto', type=click.str())
 @main.command()
 def get(**kwargs):
     """ Fetch analysis inputs.

--- a/neuroscout_cli/cli.py
+++ b/neuroscout_cli/cli.py
@@ -42,7 +42,7 @@ def main():
 @click.option('--upload-first-level', is_flag=True, help='Upload first-level results, in addition to group')
 @click.option('--force-upload', is_flag=True, help='Force upload even if a NV collection already exists')
 @click.option('--no-get', is_flag=True, help="Don't automatically fetch bundle & dataset")
-@click.option('--datalad-jobs', help='Number of parallel jobs for DataLad when fetching files', default='auto', type=click.str())
+@click.option('--datalad-jobs', help='Number of parallel jobs for DataLad when fetching files', default='auto')
 @click.option('--download-dir', help='Directory to cache input datasets, instead of OUT_DIR', type=click.Path())
 @click.argument('fitlins_options', nargs=-1, type=click.UNPROCESSED)
 @main.command(context_settings=dict(

--- a/neuroscout_cli/commands/get.py
+++ b/neuroscout_cli/commands/get.py
@@ -121,7 +121,7 @@ class Get(Command):
             paths += list(self.preproc_dir.rglob('*.json'))
 
             # Get with DataLad
-            get([str(p) for p in paths], dataset=self.dataset_dir)
+            get([str(p) for p in paths], dataset=self.dataset_dir, jobs=self.options['datalad_jobs'])
 
         except Exception as exp:
             if hasattr(exp, 'failed'):

--- a/neuroscout_cli/commands/get.py
+++ b/neuroscout_cli/commands/get.py
@@ -62,19 +62,21 @@ class Get(Command):
         else:
             download_dir = self.main_dir / 'sourcedata'
             
-        self.preproc_dir = download_dir / self.resources['dataset_name']
+        self.dataset_dir = download_dir / self.resources['dataset_name']
 
         # Install DataLad dataset if dataset_dir does not exist
-        if not self.preproc_dir.exists():
+        if not self.dataset_dir.exists():
             # Use datalad to install the preproc dataset
             install(source=self.resources['preproc_address'],
                     path=str(self.preproc_dir))
 
         # Set preproc dir to specific directory, depending on contents
         for option in ['preproc', 'fmriprep']:
-            if (self.preproc_dir / option).exists():
-                self.preproc_dir = (self.preproc_dir / option).absolute()
+            if (self.dataset_dir / option).exists():
+                self.preproc_dir = (self.dataset_dir / option).absolute()
                 break
+            else:
+                self.preproc_dir = self.dataset_dir
 
         return 0
     
@@ -128,7 +130,7 @@ class Get(Command):
             else:
                 raise exp
 
-        # Copy meta-data to root of dataset_dir
+        # Copy meta-data to root of preproc_dir
         copy(list(self.bundle_dir.glob('task-*json'))[0], self.preproc_dir)
 
         return 0

--- a/neuroscout_cli/commands/get.py
+++ b/neuroscout_cli/commands/get.py
@@ -121,7 +121,7 @@ class Get(Command):
             paths += list(self.preproc_dir.rglob('*.json'))
 
             # Get with DataLad
-            get([str(p) for p in paths], dataset=self.preproc_dir.parent)
+            get([str(p) for p in paths], dataset=self.dataset_dir)
 
         except Exception as exp:
             if hasattr(exp, 'failed'):


### PR DESCRIPTION
- For narratives dataset, there is no `preproc` or `fmriprep` directory, so the `dataset_dir` is the `preproc dir`. 
Saving `dataset_dir` explicitly for DataLad to be able to locate the dataset and `get` files.